### PR TITLE
resolve issue #10

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015-loose-rollup", "react"],
+  "presets": ["es2015", "react"],
   "plugins": ["transform-class-properties", "transform-export-extensions"]
 }

--- a/examples/simple/Game.js
+++ b/examples/simple/Game.js
@@ -1,21 +1,21 @@
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 
-import {Viewport, SceneDirector, Scene, GameObject, Behavior, Texture} from 'moirai';
+import {Viewport, SceneDirector, GameObject, Behavior, Texture} from 'moirai';
+
+const Scene1 = () => (
+  <GameObject>
+    <Texture source="http://facebook.github.io/react/img/logo.svg"/>
+    <Behavior
+      onUpdate={function(dt, gameObject) { gameObject.setState({x: gameObject.state.x + (dt * 10)}); }}/>
+  </GameObject>
+)
 
 class Game extends Component {
   render() {
     return (
       <Viewport>
-        <SceneDirector>
-          <Scene>
-            <GameObject>
-              <Texture source="http://facebook.github.io/react/img/logo.svg"/>
-              <Behavior
-                onUpdate={function(dt, gameObject) { gameObject.setState({x: gameObject.state.x + (dt * 10)}); }}/>
-            </GameObject>
-          </Scene>
-        </SceneDirector>
+        <SceneDirector scenes={{Scene1}} />
       </Viewport>
     );
   }

--- a/package.json
+++ b/package.json
@@ -26,11 +26,20 @@
     "url": "https://github.com/freezedev/moirai/issues"
   },
   "homepage": "https://github.com/freezedev/moirai",
+  "rollupBabelLibBundler": {
+    "moduleName": "moirai",
+    "dest": "dist",
+    "babel": {
+      "presets": ["es2015-loose-rollup", "react"],
+      "plugins": ["transform-class-properties", "transform-export-extensions"]
+    }
+  },
   "devDependencies": {
     "babel-core": "^6.4.5",
     "babel-loader": "^6.2.1",
     "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-plugin-transform-export-extensions": "^6.5.0",
+    "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-loose-rollup": "^7.0.0",
     "babel-preset-react": "^6.3.13",
     "react-dom": "^0.14.3",


### PR DESCRIPTION
(Resolves frostney/moirai#10.)

I think there are potentially some significant issues with `rollup-babel-lib-bundler` (or perhaps `babel-preset-es2015-loose-rollup`) that you might eventually have to track down. In the meantime I've segregated the bundler so that it only runs on `npm run build`. Webpack (via `npm run examples`) is now using the "normal" ES2015 preset, which works correctly. My unsolicited advice is to rethink whether developing `rollup-babel-lib-bundler` and `babel-preset-es2015-loose-rollup` is a good idea – build tools are tricky to get right and maintain, especially with the amount of flux going on in babel & webpack land these days.

Separately I had to ditch the `<Scene />` component, create my own `Scene1` component, and pass it into the `scenes` param of the `<SceneDirector />` instead of as a child component due to changes in the way `react-scenedirector` works.
